### PR TITLE
[BUG] Fixing typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ qiskit-ibm-runtime>=0.32.0
 qiskit-aer
 qiskit-ibm-transpiler
 qiskit-serverless
-qiskit-ibm-catalogue
+qiskit-ibm-catalog
 networkx
 colorama
 jupyter


### PR DESCRIPTION
# Summary

I noticed a typo in the `requirements.txt` during setup. I'm pretty sure `qiskit-ibm-catalogue` should be `qiskit-ibm-catalog`.