### PR TITLE
fix pip installing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ qiskit-ibm-runtime>=0.32.0
 qiskit-aer
 qiskit-ibm-transpiler
 qiskit-serverless
-qiskit-ibm-catalogue
+qiskit-ibm-catalog
 networkx
 colorama
 jupyter


### PR DESCRIPTION
`catalogue` should be `catalog` to match the [pypi repo](https://pypi.org/project/qiskit-ibm-catalog/). this pr fixes the spelling