### PR TITLE
Add CI system

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - 'stable/**'
+  pull_request:
+    branches:
+      - main
+      - 'stable/**'
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  tests:
+    name: tests (${{ matrix.os }}, ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Test using tox environment
+        run: |
+          tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = py{310,311,312}
+skipsdist = true
+
+[testenv]
+commands =
+  #pytest --nbmake --nbmake-timeout=300 {posargs}
+deps =
+  -r requirements.txt
+  pytest
+  pytest-randomly
+  nbmake
+
+[pytest]
+addopts = --durations=10


### PR DESCRIPTION
This supersedes #4.  Since it's from a branch inside the repo, we can test before we merge it.

It's a very basic CI system, that tests only that all dependencies can be installed simultaneously.